### PR TITLE
Add support for time element

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var TRXReporter = function (baseReporterDecorator, config, emitter, logger, help
     var testListIdNotInAList;
     var testEntries;
     var results;
+    var times;
 
     var getTimestamp = function () {
         // todo: use local time ?
@@ -33,16 +34,21 @@ var TRXReporter = function (baseReporterDecorator, config, emitter, logger, help
 
     this.onRunStart = function () {
         var userName = process.env['USERNAME'];
-
+        var runStartTimestamp = getTimestamp();
         testRun = builder.create("TestRun", {version: '1.0', encoding: 'UTF-8'})
             .att('id', newGuid())
-            .att('name', userName + '@' + hostName + ' ' + getTimestamp())
+            .att('name', userName + '@' + hostName + ' ' + runStartTimestamp)
             .att('runUser', userName)
             .att('xmlns', 'http://microsoft.com/schemas/VisualStudio/TeamTest/2010');
 
         testRun.ele('TestSettings')
             .att('name', 'Karma Test Run')
             .att('id', newGuid());
+
+        times = testRun.ele('Times')
+        times.att('creation', runStartTimestamp)
+        times.att('queuing', runStartTimestamp)
+        times.att('start', runStartTimestamp);
 
         resultSummary = testRun.ele('ResultSummary');
         counters = resultSummary.ele('Counters');
@@ -86,6 +92,7 @@ var TRXReporter = function (baseReporterDecorator, config, emitter, logger, help
     };
 
     this.onRunComplete = function () {
+        times.att('finish', getTimestamp());
         var xmlToOutput = testRun;
 
         helper.mkdirIfNotExists(path.dirname(outputFile), function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-trx-reporter",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A Karma plugin. Report results in MSTest trx format.",
   "main": "index.js",
   "scripts": {
@@ -44,6 +44,6 @@
   "bugs": {
     "url": "https://github.com/hatchteam/karma-trx-reporter/issues"
   },
-  "_id": "karma-trx-reporter@0.2.4",
-  "_from": "karma-trx-reporter@~0.2.4"
+  "_id": "karma-trx-reporter@0.2.5",
+  "_from": "karma-trx-reporter@~0.2.5"
 }


### PR DESCRIPTION
Add support for trx Times element. What prompted the change was that the Times element is required to upload TRX results using the new Team Foundation Build 2015 build system.