### PR TITLE
Fixed issue with new VS Build System

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,12 @@ var TRXReporter = function (baseReporterDecorator, config, emitter, logger, help
         testRun.ele('TestSettings')
             .att('name', 'Karma Test Run')
             .att('id', newGuid());
+			
+		testRun.ele('Times')
+			.att('creation', getTimestamp())
+			.att('queuing', getTimestamp())
+			.att('start', getTimestamp())
+			.att('finish', getTimestamp());
 
         resultSummary = testRun.ele('ResultSummary');
         counters = resultSummary.ele('Counters');


### PR DESCRIPTION
Element times are required to be in the outputted XML for the new VSO
build system to pick them up.  This commit adds those times so that the reporter can be used with the new TFS/Visual Studio Online build system