### PR TITLE
Add missing plugins config to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ npm install karma-trx-reporter --save-dev
 // karma.conf.js
 module.exports = function(config) {
   config.set({
+    plugins: [
+      ...
+      require('karma-trx-reporter')
+    ],
+    
     reporters: ['progress', 'trx'],
 
     // the default configuration

--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ module.exports = function(config) {
     reporters: ['progress', 'trx'],
 
     // the default configuration
-	trxReporter: { outputFile: 'test-results.trx', shortTestName: false }
+    trxReporter: {
+      outputFile: 'test-results.trx',
+      shortTestName: false
+    }
   });
 };
 ```


### PR DESCRIPTION
A config section is missing, registering the plugin. I've added that, and reformatted another line.