### PR TITLE
Stop trimming timestamps by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var builder = require('xmlbuilder');
 var TRXReporter = function (baseReporterDecorator, config, emitter, logger, helper, formatError) {
     var outputFile = config.outputFile;
     var shortTestName = !!config.shortTestName;
+    var trimTimestamps = !!config.trimTimestamps;
     var log = logger.create('reporter.trx');
     var hostName = require('os').hostname();
     var testRun;
@@ -18,7 +19,9 @@ var TRXReporter = function (baseReporterDecorator, config, emitter, logger, help
 
     var getTimestamp = function () {
         // todo: use local time ?
-        return (new Date()).toISOString().substr(0, 19);
+        return trimTimestamps
+            ? new Date().toISOString().substr(0, 19)
+            : new Date().toISOString();
     };
 
     var s4 = function () {


### PR DESCRIPTION
Resolves #16.

Full ISO date format was tested with VS2017 and SonarQube - no issues.

Feel free to suggest a better name for a switch.