### PR TITLE
Providing a default for username in the instance one is not set

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ var TRXReporter = function (baseReporterDecorator, config, emitter, logger, help
     baseReporterDecorator(this);
 
     this.onRunStart = function () {
-        var userName = process.env.USERNAME || process.env.USER;
+        var userName = process.env.USERNAME || process.env.USER || "karma-trx";
         var runStartTimestamp = getTimestamp();
         testRun = builder.create("TestRun", {version: '1.0', encoding: 'UTF-8'})
             .att('id', newGuid())


### PR DESCRIPTION
Not having this set in the environment currently causes the reporter to crash.  This lack of USER or USERNAME environment variable occurs within a Visual Studio DevOps self-hosted image.  This should add resiliency to the reporter.