### PR TITLE
Disallow negative duration which causes invalid trx files

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ var TRXReporter = function (baseReporterDecorator, config, emitter, logger, help
             .att('testId', unitTestId)
             .att('testName', unitTestName)
             .att('computerName', hostName)
-            .att('duration', formatDuration(result.time || 0))
+            .att('duration', formatDuration(result.time > 0 ? result.time : 0))
             .att('startTime', getTimestamp())
             .att('endTime', getTimestamp())
             // todo: are there other test types?


### PR DESCRIPTION
# Problem
A `<UnitTestResult>` is occasionally reported with an invalid duration like this: `duration="00:00:00.00-32"`. When loading the trx in Visual Studio, this causes an error dialog with the message "String was not recognized as a valid TimeSpan".

# Solution
I'm guessing that the duration provided by karma is negative. As this is an insane value for a test duration, I'm coercing negative values to 0 before passing into `formatDuration()`.

# Testing
I verified that `undefined > 0` and `null > 0` are both false so the reasons for the initial check should still be satisfied by the new check.