### PR TITLE
Fix test result aggregation when trx report is used along with karma-parallel aggregatedReporterTest option

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,8 +140,9 @@ var TRXReporter = function(
                 'Merging result(s) from parallel test run(s) into the trx report.'
             );
             try {
-                for (var i in browser.lastResult._realLastResults) {
-                    var item = browser.lastResult._realLastResults[i];
+                var realLastResult = browser.lastResult._realLastResults;
+                for (var i in realLastResult) {
+                    var item = realLastResult[i];
                     total += item.total;
                     executed += item.total - item.skipped;
                     successful += item.success;

--- a/index.js
+++ b/index.js
@@ -2,11 +2,18 @@ var path = require('path');
 var fs = require('fs');
 var builder = require('xmlbuilder');
 
-function defaultNameFormatter (browser, result) {
+function defaultNameFormatter(browser, result) {
     return browser.name + '_' + result.description;
 }
 
-var TRXReporter = function (baseReporterDecorator, config, emitter, logger, helper, formatError) {
+var TRXReporter = function(
+    baseReporterDecorator,
+    config,
+    emitter,
+    logger,
+    helper,
+    formatError
+) {
     var outputFile = config.outputFile;
     var shortTestName = !!config.shortTestName;
     var trimTimestamps = !!config.trimTimestamps;
@@ -22,24 +29,37 @@ var TRXReporter = function (baseReporterDecorator, config, emitter, logger, help
     var results;
     var times;
 
-    var getTimestamp = function () {
+    var getTimestamp = function() {
         // todo: use local time ?
-        return trimTimestamps
-            ? new Date().toISOString().substr(0, 19)
-            : new Date().toISOString();
+        return trimTimestamps ?
+            new Date().toISOString().substr(0, 19) :
+            new Date().toISOString();
     };
 
-    var s4 = function () {
+    var s4 = function() {
         return Math.floor((1 + Math.random()) * 0x10000)
             .toString(16)
             .substring(1);
     };
 
-    var newGuid = function () {
-        return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
+    var newGuid = function() {
+        return (
+            s4() +
+            s4() +
+            '-' +
+            s4() +
+            '-' +
+            s4() +
+            '-' +
+            s4() +
+            '-' +
+            s4() +
+            s4() +
+            s4()
+        );
     };
 
-    var formatDuration = function (duration) {
+    var formatDuration = function(duration) {
         duration = duration | 0;
         var ms = duration % 1000;
         duration -= ms;
@@ -51,25 +71,32 @@ var TRXReporter = function (baseReporterDecorator, config, emitter, logger, help
         duration -= h * 3600000;
         var d = duration / 86400000;
 
-        return (d > 0 ? d + '.' : '') +
-            (h < 10 ? '0' + h : h) + ':' +
-            (m < 10 ? '0' + m : m) + ':' +
-            (s < 10 ? '0' + s : s) + '.' +
-            (ms < 10 ? '00' + ms : ms < 100 ? '0' + ms : ms);
+        return (
+            (d > 0 ? d + '.' : '') +
+            (h < 10 ? '0' + h : h) +
+            ':' +
+            (m < 10 ? '0' + m : m) +
+            ':' +
+            (s < 10 ? '0' + s : s) +
+            '.' +
+            (ms < 10 ? '00' + ms : ms < 100 ? '0' + ms : ms)
+        );
     };
 
     baseReporterDecorator(this);
 
-    this.onRunStart = function () {
-        var userName = process.env.USERNAME || process.env.USER || "karma-trx";
+    this.onRunStart = function() {
+        var userName = process.env.USERNAME || process.env.USER || 'karma-trx';
         var runStartTimestamp = getTimestamp();
-        testRun = builder.create("TestRun", {version: '1.0', encoding: 'UTF-8'})
+        testRun = builder
+            .create('TestRun', { version: '1.0', encoding: 'UTF-8' })
             .att('id', newGuid())
             .att('name', userName + '@' + hostName + ' ' + runStartTimestamp)
             .att('runUser', userName)
             .att('xmlns', 'http://microsoft.com/schemas/VisualStudio/TeamTest/2010');
 
-        testRun.ele('TestSettings')
+        testRun
+            .ele('TestSettings')
             .att('name', 'Karma Test Run')
             .att('id', newGuid());
 
@@ -82,49 +109,79 @@ var TRXReporter = function (baseReporterDecorator, config, emitter, logger, help
         counters = resultSummary.ele('Counters');
         testDefinitions = testRun.ele('TestDefinitions');
 
-        testListIdNotInAList = "8c84fa94-04c1-424b-9868-57a2d4851a1d";
+        testListIdNotInAList = '8c84fa94-04c1-424b-9868-57a2d4851a1d';
         var testLists = testRun.ele('TestLists');
 
-        testLists.ele('TestList')
+        testLists
+            .ele('TestList')
             .att('name', 'Results Not in a List')
             .att('id', testListIdNotInAList);
 
         // seems to be VS is expecting that exact id
-        testLists.ele('TestList')
+        testLists
+            .ele('TestList')
             .att('name', 'All Loaded Results')
-            .att('id', "19431567-8539-422a-85d7-44ee4e166bda");
+            .att('id', '19431567-8539-422a-85d7-44ee4e166bda');
 
         testEntries = testRun.ele('TestEntries');
         results = testRun.ele('Results');
     };
 
-    this.onBrowserStart = function(browser) {
-    };
+    this.onBrowserStart = function(browser) {};
 
-    this.onBrowserComplete = function (browser) {
-        var result = browser.lastResult;
-
-        var passed = result.failed <= 0 && !result.error;
+    this.onBrowserComplete = function(browser) {
+        var total = 0;
+        var executed = 0;
+        var successful = 0;
+        var error = 0;
+        var failed = 0;
+        if (browser.lastResult._realLastResults) {
+            console.log(
+                'Merging result(s) from parallel test run(s) into the trx report.'
+            );
+            try {
+                for (var i in browser.lastResult._realLastResults) {
+                    var item = browser.lastResult._realLastResults[i];
+                    total += item.total;
+                    executed += item.total - item.skipped;
+                    successful += item.success;
+                    error += item.error ? 1 : 0;
+                    failed += item.failed;
+                }
+                console.log('Merge was successful.');
+            } catch (e) {
+                console.error(`Merge failed with error: ${e}`);
+            }
+        } else {
+            var result = browser.lastResult;
+            // todo: checkout if all theses numbers map well
+            total = result.total;
+            executed = result.total - result.skipped;
+            successful = result.success;
+            error = result.error ? 1 : 0;
+            failed = result.failed;
+        }
+        var passed = failed <= 0 && !error;
         resultSummary.att('outcome', passed ? 'Passed' : 'Failed');
-
-        // todo: checkout if all theses numbers map well
-        counters.att('total', result.total)
-            .att('executed', result.total - result.skipped)
-            .att('passed', result.success)
-            .att('error', result.error ? 1 : 0)
-            .att('failed', result.failed);
-
+        counters
+            .att('total', total)
+            .att('executed', executed)
+            .att('passed', successful)
+            .att('error', error)
+            .att('failed', failed);
         // possible useful info:
         // todo: result.disconnected => this seems to happen occasionally? => Possibly handle it!
         // (result.netTime || 0) / 1000)
     };
 
-    this.onRunComplete = function () {
+    this.onRunComplete = function() {
         times.att('finish', getTimestamp());
         var xmlToOutput = testRun;
 
-        helper.mkdirIfNotExists(path.dirname(outputFile), function () {
-            fs.writeFile(outputFile, xmlToOutput.end({pretty: true}), function (err) {
+        helper.mkdirIfNotExists(path.dirname(outputFile), function() {
+            fs.writeFile(outputFile, xmlToOutput.end({ pretty: true }), function(
+                err
+            ) {
                 if (err) {
                     log.warn('Cannot write TRX testRun\n\t' + err.message);
                 } else {
@@ -134,31 +191,37 @@ var TRXReporter = function (baseReporterDecorator, config, emitter, logger, help
         });
     };
 
-    this.specSuccess = this.specSkipped = this.specFailure = function (browser, result) {
+    this.specSuccess = this.specSkipped = this.specFailure = function(
+        browser,
+        result
+    ) {
         var unitTestId = newGuid();
-        var unitTestName = shortTestName 
-            ? result.description 
-            : nameFormatter(browser, result);
+        var unitTestName = shortTestName ?
+            result.description :
+            nameFormatter(browser, result);
         var className = result.suite.join('.');
         var codeBase = className + '.' + unitTestName;
 
-        var unitTest = testDefinitions.ele('UnitTest')
+        var unitTest = testDefinitions
+            .ele('UnitTest')
             .att('name', unitTestName)
             .att('id', unitTestId);
         var executionId = newGuid();
-        unitTest.ele('Execution')
-            .att('id', executionId);
-        unitTest.ele('TestMethod')
+        unitTest.ele('Execution').att('id', executionId);
+        unitTest
+            .ele('TestMethod')
             .att('codeBase', codeBase)
             .att('name', unitTestName)
             .att('className', className);
 
-        testEntries.ele('TestEntry')
+        testEntries
+            .ele('TestEntry')
             .att('testId', unitTestId)
             .att('executionId', executionId)
             .att('testListId', testListIdNotInAList);
 
-        var unitTestResult = results.ele('UnitTestResult')
+        var unitTestResult = results
+            .ele('UnitTestResult')
             .att('executionId', executionId)
             .att('testId', unitTestId)
             .att('testName', unitTestName)
@@ -168,19 +231,29 @@ var TRXReporter = function (baseReporterDecorator, config, emitter, logger, help
             .att('endTime', getTimestamp())
             // todo: are there other test types?
             .att('testType', '13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b') // that guid seems to represent 'unit test'
-            .att('outcome', result.skipped ? 'NotExecuted' : (result.success ? 'Passed' : 'Failed'))
+            .att(
+                'outcome',
+                result.skipped ? 'NotExecuted' : result.success ? 'Passed' : 'Failed'
+            )
             .att('testListId', testListIdNotInAList);
 
         if (!result.success) {
-            unitTestResult.ele('Output')
+            unitTestResult
+                .ele('Output')
                 .ele('ErrorInfo')
-                .ele('Message', formatError(result.log[0]))
+                .ele('Message', formatError(result.log[0]));
         }
     };
 };
 
-TRXReporter.$inject = ['baseReporterDecorator', 'config.trxReporter', 'emitter', 'logger',
-    'helper', 'formatError'];
+TRXReporter.$inject = [
+    'baseReporterDecorator',
+    'config.trxReporter',
+    'emitter',
+    'logger',
+    'helper',
+    'formatError'
+];
 
 // PUBLISH DI MODULE
 module.exports = {


### PR DESCRIPTION
when karma-parallel is configured using karma.conf.js as below to aggregate trx results test fails with error. without any configuration only last finished parallel test result is written into trx output.
with the PR fix is karma parallel is used we will get aggregated result. Otherwise trx will output results as usual.
Please find the karma.conf.js content below:
// Karma configuration file, see link for more information
// https://karma-runner.github.io/1.0/config/configuration-file.html

module.exports = function (config) {
  config.set({
    basePath: '',
    frameworks: ['parallel', 'jasmine', '@angular-devkit/build-angular'],
    plugins: [
      require('karma-parallel'),
      require('karma-jasmine'),
      require('karma-chrome-launcher'),
      require('karma-ie-launcher'),
      require('karma-jasmine-html-reporter'),
      require('karma-coverage-istanbul-reporter'),
      require('karma-trx-reporter'),
      require('@angular-devkit/build-angular/plugins/karma')
    ],
    parallelOptions: {
      executors: config.browsers && config.browsers.length === 1 && config.browsers[0] === 'ChromeHeadless' ? 5 : 1, // Defaults to cpu-count - 1 // ng test does not support custom args. hence using browsers flag
      shardStrategy: 'round-robin',
      aggregatedReporterTest: /coverage|istanbul|trx/i
      // shardStrategy: 'description-length'
      // shardStrategy: 'custom'
      // customShardStrategy: function(config) {
      //   config.executors // number, the executors set above
      //   config.shardIndex // number, the specific index for the shard currently running
      //   config.description // string, the name of the top-level describe string. Useful //     for determining how to shard the current specs
      //   return config.
      // }
    },
    client: {
      clearContext: false, // leave Jasmine Spec Runner output visible in browser
      jasmine: {
        random: false
      }
    },
    files: [
      './node_modules/devextreme/dist/css/dx.common.css',
      './node_modules/devextreme/dist/css/dx.light.css',
      {
        pattern: './node_modules/devextreme/dist/css/icons/*',
        watched: false,
        served: true,
        included: false
      }
    ],
    browserNoActivityTimeout: 30000,
    trxReporter: {
      outputFile: 'karma-test-results.trx',
      shortTestName: false
    },
    coverageIstanbulReporter: {
      dir: require('path').join(__dirname, './coverage'),
      reports: ['html', 'lcovonly'],
      fixWebpackSourcePaths: true
    },
    angularCli: {
      environment: 'dev'
    },
    reporters: ['progress', 'kjhtml', 'trx'],
    port: 9876,
    colors: true,
    logLevel: config.LOG_INFO,
    autoWatch: true,
    browsers: ['Chrome'],
    customLaunchers: {
      IE_no_addons: {
        base: 'IE',
        flags: ['-extoff']
      }
    },
    singleRun: false
  });
};
