### PR TITLE
Added try-catch block to onRunComplete() callback to catch errors when the source code contains error

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,18 +120,23 @@ var TRXReporter = function (baseReporterDecorator, config, emitter, logger, help
     };
 
     this.onRunComplete = function () {
-        times.att('finish', getTimestamp());
-        var xmlToOutput = testRun;
-
-        helper.mkdirIfNotExists(path.dirname(outputFile), function () {
-            fs.writeFile(outputFile, xmlToOutput.end({pretty: true}), function (err) {
-                if (err) {
-                    log.warn('Cannot write TRX testRun\n\t' + err.message);
-                } else {
-                    log.debug('TRX results written to "%s".', outputFile);
-                }
+        try {
+            times.att('finish', getTimestamp());
+            var xmlToOutput = testRun;
+    
+            helper.mkdirIfNotExists(path.dirname(outputFile), function () {
+                fs.writeFile(outputFile, xmlToOutput.end({pretty: true}), function (err) {
+                    if (err) {
+                        log.warn('Cannot write TRX testRun\n\t' + err.message);
+                    } else {
+                        log.debug('TRX results written to "%s".', outputFile);
+                    }
+                });
             });
-        });
+        } catch (e) {
+            console.log(e);
+        }
+        
     };
 
     this.specSuccess = this.specSkipped = this.specFailure = function (browser, result) {


### PR DESCRIPTION
We're using this package in our project and we faced with an interesting problem: when we run "ng test" and our source code contains any error it will try to run karma and browser forever without any progress until we stop the process. The problem is that there's no try-catch block to process the build error properly. This PR can solve the problem and show the error in the console.